### PR TITLE
Fixing error related to "next" keyword (`void value expression` error)

### DIFF
--- a/lib/smooch-api/models/get_messages_response.rb
+++ b/lib/smooch-api/models/get_messages_response.rb
@@ -87,7 +87,7 @@ module SmoochApi
       self.class == o.class &&
           conversation == o.conversation &&
           messages == o.messages &&
-          next == o.next
+          self.next == o.next
     end
 
     # @see the `==` method
@@ -99,7 +99,7 @@ module SmoochApi
     # Calculates hash code according to all attributes.
     # @return [Fixnum] Hash code
     def hash
-      [conversation, messages, next].hash
+      [conversation, messages, self.next].hash
     end
 
     # Builds the object from hash


### PR DESCRIPTION
Hello,

I know `smooch-ruby` is auto-generated, so, this fix should probably go into the generator level. Anyway, it might still be useful if anyone is facing the same problem. I was getting the following error when trying to use the `list_integrations` method:

> /var/lib/gems/2.3.0/gems/smooch-api-4.2.0/lib/smooch-api.rb:44:in `require':
> /var/lib/gems/2.3.0/gems/smooch-api-4.2.0/lib/smooch-api/models/get_messages_response.rb:90: 
> void value expression (SyntaxError)
> /var/lib/gems/2.3.0/gems/smooch-api-4.2.0/lib/smooch-api/models/get_messages_response.rb:102: 
> void value expression
> [conversation, messages, next].hash
>                                    ^
> from /var/lib/gems/2.3.0/gems/smooch-api-4.2.0/lib/smooch-api.rb:44:in `<top (required)>'
> from smooch.rb:8:in `require'
> from smooch.rb:8:in `<main>'

The problem is because `next` is a reserved word and it's being used as an attribute here. The fix was to just prepend `next` with `self.`.